### PR TITLE
Move integration tests to swiftwasm-build

### DIFF
--- a/.github/workflows/build-toolchain.yml
+++ b/.github/workflows/build-toolchain.yml
@@ -304,14 +304,12 @@ jobs:
         with:
           name: ${{ matrix.target }}-hello.wasm
           path: hello.wasm
-      - name: Checkout integration-tests
+
+      - uses: bytecodealliance/actions/wasmtime/setup@v1
         if: ${{ matrix.run_e2e_test }}
-        uses: actions/checkout@v4
         with:
-          repository: swiftwasm/integration-tests
-          path: integration-tests
+          version: "v17.0.1"
+          github_token: ${{ secrets.GITHUB_TOKEN }}
       - name: Run integration tests
         if: ${{ matrix.run_e2e_test }}
-        run: |
-          $TOOLCHAIN/usr/bin/swift run # Use TOOLCHAIN env value
-        working-directory: ${{ github.workspace }}/integration-tests
+        run: ${{ github.workspace }}/llvm-project/llvm/utils/lit/lit.py --param package-path=$TOOLCHAIN ${{ github.workspace }}/swiftwasm-build/test -vv

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -1,0 +1,57 @@
+# vim: set syntax=python sw=4:
+
+import platform
+import os
+import shutil
+
+import lit.formats
+
+config.name = "swift-extra-integration-tests"
+
+test_source_root = os.path.dirname(os.path.abspath(__file__))
+workspace_root = os.path.dirname(os.path.dirname(test_source_root))
+
+config.test_source_root = os.path.join(test_source_root)
+config.test_format = lit.formats.ShTest(execute_external = False)
+
+config.suffixes = [".test", ".swift"]
+config.excludes = ["Inputs"]
+config.test_exec_root = lit_config.params.get(
+    "test-exec-root",
+    "/tmp/swift-extra-integration-tests")
+
+config.available_features.add("platform="+platform.system())
+
+package_path = lit_config.params.get("package-path")
+if package_path:
+    package_path = os.path.abspath(package_path)
+    lit_config.note(f"testing toolchain package: {package_path}")
+else:
+    lit_config.warning("'--param package-path=PATH' is not set, skipping toolchain tests")
+config.swift_package_path = package_path
+
+def llvm_tool_path(tool):
+    candidates = []
+    llvm_bin = lit_config.params.get("llvm-bin")
+    if llvm_bin:
+        candidates.append(os.path.join(llvm_bin, tool))
+    build_bin = os.path.join(workspace_root, "build", "llvm-tools", "bin")
+    candidates.append(os.path.join(build_bin, tool))
+    for candidate in candidates:
+        if os.path.exists(candidate):
+            return candidate
+    return shutil.which(tool)
+
+maybe_wasmtime = shutil.which("wasmtime")
+if maybe_wasmtime:
+    config.substitutions.append(('%{wasm_run}', f'{maybe_wasmtime} run'))
+else:
+    lit_config.warning("cannot find wasmtime, some tests may be disabled")
+    config.substitutions.append(('%{wasm_run}', 'echo "wasmtime not found"'))
+
+for llvm_tool in ["FileCheck"]:
+    llvm_tool_path_value = llvm_tool_path(llvm_tool)
+    if llvm_tool_path_value:
+        config.substitutions.append(('%{' + llvm_tool + '}', llvm_tool_path_value))
+    else:
+        lit_config.warning(f"cannot find {llvm_tool}, some tests may be disabled")

--- a/test/toolchain/Inputs/imports.swift
+++ b/test/toolchain/Inputs/imports.swift
@@ -1,0 +1,18 @@
+import Foundation
+import XCTest
+import WASILibc
+
+// FIXME: This should be supported on swiftwasm branch
+// #if canImport(FoundationXML)
+//   #error("FoundationXML should not be able to import now")
+// #endif
+// 
+// #if canImport(FoundationNetworking)
+//   #error("FoundationNetworking should not be able to import now")
+// #endif
+
+public func main() {
+  _ = Date()
+  _ = UUID()
+  _ = URL(string: "https://example.com")!
+}

--- a/test/toolchain/basic.swift
+++ b/test/toolchain/basic.swift
@@ -1,0 +1,3 @@
+// RUN: %{swiftc} -target wasm32-unknown-wasi -static-stdlib -sdk %{package_path}/usr/share/wasi-sysroot %s -o %t.wasm
+// RUN: %{wasm_run} %t.wasm
+print("Hello")

--- a/test/toolchain/import-system-modules.swift
+++ b/test/toolchain/import-system-modules.swift
@@ -1,0 +1,2 @@
+// RUN: %{swiftc} -resource-dir %{package_path}/usr/lib/swift_static -target wasm32-wasi %S/Inputs/imports.swift -sdk %{package_path}/usr/share/wasi-sysroot -static-stdlib -o %t.wasm
+// RUN: %{wasm_run} %t.wasm

--- a/test/toolchain/lit.local.cfg
+++ b/test/toolchain/lit.local.cfg
@@ -1,0 +1,11 @@
+import os
+
+if not config.root.swift_package_path:
+    config.unsupported = True
+
+bin_path = os.path.join(config.root.swift_package_path, "usr", "bin")
+
+for tool in ["swift", "swiftc"]:
+    config.substitutions.append(("%{" + tool + "}", os.path.join(bin_path, tool)))
+
+config.substitutions.append(("%{package_path}", config.root.swift_package_path))

--- a/test/toolchain/swiftpm-build.swift
+++ b/test/toolchain/swiftpm-build.swift
@@ -1,0 +1,5 @@
+// RUN: rm -rf %t.dir
+// RUN: mkdir -p %t.dir
+// RUN: %{swift} package init --package-path %t.dir --name Example
+// RUN: cp %S/Inputs/imports.swift %t.dir/Sources/Example/Imports.swift
+// RUN: %{swift} build --package-path %t.dir --triple wasm32-unknown-wasi -Xswiftc -static-stdlib -Xswiftc -resource-dir -Xswiftc %{package_path}/usr/lib/swift_static

--- a/test/toolchain/swiftpm-test.test
+++ b/test/toolchain/swiftpm-test.test
@@ -1,0 +1,7 @@
+# Skipping, see https://github.com/swiftwasm/swift/issues/5551
+XFAIL: *
+
+RUN: rm -rf %t.dir
+RUN: mkdir -p %t.dir
+RUN: %{swift} package init --package-path %t.dir --name Example
+RUN: %{swift} build --package-path %t.dir --triple wasm32-unknown-wasi --build-tests -Xswiftc -resource-dir -Xswiftc %{package_path}/usr/lib/swift_static


### PR DESCRIPTION
And also migrate the integration tests to use `lit` for running the tests.

This makes it easier to update tests while changing toolchain code.