### PR TITLE
Fix Clang header installation

### DIFF
--- a/.github/workflows/build-toolchain.yml
+++ b/.github/workflows/build-toolchain.yml
@@ -312,4 +312,4 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
       - name: Run integration tests
         if: ${{ matrix.run_e2e_test }}
-        run: ${{ github.workspace }}/llvm-project/llvm/utils/lit/lit.py --param package-path=$TOOLCHAIN ${{ github.workspace }}/swiftwasm-build/test -vv
+        run: ${{ github.workspace }}/llvm-project/llvm/utils/lit/lit.py --param package-path=$TOOLCHAIN --param scheme=${{ matrix.scheme }} ${{ github.workspace }}/swiftwasm-build/test -vv

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -21,6 +21,7 @@ config.test_exec_root = lit_config.params.get(
     "/tmp/swift-extra-integration-tests")
 
 config.available_features.add("platform="+platform.system())
+config.available_features.add("scheme="+lit_config.params.get("scheme", "main"))
 
 package_path = lit_config.params.get("package-path")
 if package_path:

--- a/test/toolchain/Inputs/clang-module-example/Package.swift
+++ b/test/toolchain/Inputs/clang-module-example/Package.swift
@@ -1,0 +1,11 @@
+// swift-tools-version: 5.8
+
+import PackageDescription
+
+let package = Package(
+    name: "ClangModuleExample",
+    targets: [
+        .executableTarget(name: "Main", dependencies: ["_CModule"]),
+        .target(name: "_CModule"),
+    ]
+)

--- a/test/toolchain/Inputs/clang-module-example/Sources/Main/ClangModuleExample.swift
+++ b/test/toolchain/Inputs/clang-module-example/Sources/Main/ClangModuleExample.swift
@@ -1,0 +1,1 @@
+import _CModule

--- a/test/toolchain/Inputs/clang-module-example/Sources/_CModule/_CModule.c
+++ b/test/toolchain/Inputs/clang-module-example/Sources/_CModule/_CModule.c
@@ -1,0 +1,1 @@
+#include "_CModule.h"

--- a/test/toolchain/Inputs/clang-module-example/Sources/_CModule/include/_CModule.h
+++ b/test/toolchain/Inputs/clang-module-example/Sources/_CModule/include/_CModule.h
@@ -1,0 +1,4 @@
+#include <stddef.h> // Clang header should be found
+#if __wasi__
+# include <wasi/api.h> // wasi-libc header
+#endif

--- a/test/toolchain/Inputs/clang-module-example/Sources/_CModule/include/module.modulemap
+++ b/test/toolchain/Inputs/clang-module-example/Sources/_CModule/include/module.modulemap
@@ -1,0 +1,3 @@
+module _CModule {
+  header "_CModule.h"
+}

--- a/test/toolchain/clang-module.swift
+++ b/test/toolchain/clang-module.swift
@@ -1,0 +1,3 @@
+// RUN: rm -rf %t.dir
+// RUN: mkdir -p %t.dir
+// RUN: %{swift} build --package-path %S/Inputs/clang-module-example --scratch-path %t.dir --triple wasm32-unknown-wasi --static-swift-stdlib

--- a/test/toolchain/swiftpm-test.test
+++ b/test/toolchain/swiftpm-test.test
@@ -1,5 +1,5 @@
 # Skipping, see https://github.com/swiftwasm/swift/issues/5551
-XFAIL: *
+XFAIL: scheme=main || scheme=release-5.10
 
 RUN: rm -rf %t.dir
 RUN: mkdir -p %t.dir

--- a/tools/build/build-target-toolchain.sh
+++ b/tools/build/build-target-toolchain.sh
@@ -145,13 +145,8 @@ build_target_toolchain() {
   "$TOOLS_BUILD_PATH/build-foundation.sh" "${CORELIBS_ARGS[@]}"
   "$TOOLS_BUILD_PATH/build-xctest.sh" "${CORELIBS_ARGS[@]}"
 
-  # WORKAROUND: Link compiler-rt under swift resource dir
-  # This should be done by Swift build system, but it always get the resource dir from
-  # `clang -print-resource-dir` without respecting `-resource-dir` nor `-target` options.
-  rm -rf "$TARGET_TOOLCHAIN_DESTDIR/usr/lib/swift/clang"
-  rm -rf "$TARGET_TOOLCHAIN_DESTDIR/usr/lib/swift_static/clang"
-  ln -fs "../clang/$CLANG_VERSION" "$TARGET_TOOLCHAIN_DESTDIR/usr/lib/swift/clang"
-  ln -fs "../clang/$CLANG_VERSION" "$TARGET_TOOLCHAIN_DESTDIR/usr/lib/swift_static/clang"
+  ln -fs "../../../clang/$CLANG_VERSION/lib/wasi" "$TARGET_TOOLCHAIN_DESTDIR/usr/lib/swift/clang/lib/wasi"
+  ln -fs "../../../clang/$CLANG_VERSION/lib/wasi" "$TARGET_TOOLCHAIN_DESTDIR/usr/lib/swift_static/clang/lib/wasi"
 }
 
 main() {


### PR DESCRIPTION
* `usr/lib/clang` is installed by compiler-rt's install script
* `usr/lib/swift{,_static}/clang` are installed by Swift's build system
  by copying Clang headers from the base toolchain.
* `usr/lib/swift{,_static}/clang` were removed by our build script and
  replaced with symlinks to `usr/lib/clang`
* `usr/lib/clang` somehow did not include compiler headers only when
  building on macOS.
