### PR TITLE
Stop checking out swift-corelibs-foundation for a revision

### DIFF
--- a/schemes/main/manifest.json
+++ b/schemes/main/manifest.json
@@ -1,7 +1,6 @@
 {
   "base-tag": "swift-DEVELOPMENT-SNAPSHOT-2024-02-08-a",
   "repos": {
-    "swift-corelibs-foundation": "dbca8c7ddcfd19f7f6f6e1b60fd3ee3f748e263c",
     "swift-corelibs-xctest": "77bc9f5386ee8a2a4e8da5ac30e846b451d101b6"
   },
   "build-compiler": false,


### PR DESCRIPTION
The revision can be behind the `base-tag` revision, so better not to use custom revisions.