### PR TITLE
Build libclang_rt.builtin for wasip1-threads target separately

### DIFF
--- a/.github/scripts/build-matrix.rb
+++ b/.github/scripts/build-matrix.rb
@@ -7,7 +7,7 @@ BASE_MATRIX_ENTRIES = [
     "agent_query": "ubuntu-20.04",
     "target": "ubuntu18.04_x86_64",
     "containers": {
-      "main": "ghcr.io/swiftwasm/swift-ci:main-ubuntu-18.04",
+      # "main": "ghcr.io/swiftwasm/swift-ci:main-ubuntu-18.04",
       # "release-5.9": "ghcr.io/swiftwasm/swift-ci:main-ubuntu-18.04@sha256:d5d555cf48fc02f5003928a064c03b76c012fef8afbe54a1942c6bfc3d773c58",
       "release-5.10": "ghcr.io/swiftwasm/swift-ci:main-ubuntu-18.04@sha256:d5d555cf48fc02f5003928a064c03b76c012fef8afbe54a1942c6bfc3d773c58"
     },

--- a/schemes/main/manifest.json
+++ b/schemes/main/manifest.json
@@ -1,5 +1,5 @@
 {
-  "base-tag": "swift-DEVELOPMENT-SNAPSHOT-2024-04-22-a",
+  "base-tag": "swift-DEVELOPMENT-SNAPSHOT-2024-04-23-a",
   "build-compiler": false,
   "icu4c": "https://github.com/swiftwasm/icu4c-wasi/releases/download/0.8.0/icu4c-wasi.tar.xz",
   "swift-org-download-channel": "development"

--- a/schemes/main/manifest.json
+++ b/schemes/main/manifest.json
@@ -1,5 +1,5 @@
 {
-  "base-tag": "swift-DEVELOPMENT-SNAPSHOT-2024-04-13-a",
+  "base-tag": "swift-DEVELOPMENT-SNAPSHOT-2024-04-22-a",
   "build-compiler": false,
   "icu4c": "https://github.com/swiftwasm/icu4c-wasi/releases/download/0.8.0/icu4c-wasi.tar.xz",
   "swift-org-download-channel": "development"

--- a/tools/build/package-toolchain
+++ b/tools/build/package-toolchain
@@ -37,11 +37,11 @@ class SnapshotInfo:
         return f"{self.artifact_name}.artifactbundle.zip"
 
 
-def derive_wasi_sysroot(options, packaging_dir: str) -> str:
+def derive_wasi_sysroot(options, packaging_dir: str, target_triple: str) -> str:
     if options.download_wasi_sysroot:
         return os.path.join('..', 'build-sdk', 'wasi-sysroot')
     else:
-        return os.path.join(packaging_dir, 'wasi-sysroot')
+        return os.path.join(packaging_dir, 'wasi-sysroot', target_triple)
 
 
 def copy_icu_libs(build_sdk_path, dist_toolchain_path):
@@ -116,7 +116,7 @@ class PackageAction(Action):
             os.remove(swift_driver_path)
 
         # Select wasi-sysroot
-        wasi_sysroot_path = derive_wasi_sysroot(self.options, packaging_dir)
+        wasi_sysroot_path = derive_wasi_sysroot(self.options, packaging_dir, 'wasm32-wasi')
         print("=====> Using wasi-sysroot from {}".format(wasi_sysroot_path))
 
         # Now dist toolchain always has cross compiler regardless of whether
@@ -439,8 +439,9 @@ def main():
             os.path.dirname(__file__), '..', '..', '..', 'build', 'Packaging')
 
         toolchain_channel = derive_toolchain_channel(options.scheme)
-        for target_triple in [
-            "wasm32-unknown-wasi", "wasm32-unknown-wasip1-threads"
+        for target_triple, short_triple in [
+            ["wasm32-unknown-wasi", "wasm32-wasi"],
+            ["wasm32-unknown-wasip1-threads", "wasm32-wasip1-threads"]
         ]:
             snapshot_info = SnapshotInfo(
                 now.year, now.month, now.day,
@@ -454,7 +455,7 @@ def main():
                 base_toolchain_path=os.path.join(packaging_dir, 'base-snapshot'),
                 host_toolchain_path=None,
                 target_toolchain_path=os.path.join(packaging_dir, 'target-toolchain', target_triple),
-                wasi_sysroot_path=derive_wasi_sysroot(options, packaging_dir),
+                wasi_sysroot_path=derive_wasi_sysroot(options, packaging_dir, short_triple),
                 swift_sdk_name=f"{snapshot_info.swift_version}-{target_triple}",
                 target_triple=target_triple,
             ))


### PR DESCRIPTION
`compiler-rt/lib/builtins/atomic.c` has to be built with atomics feature enabled for wasip1-threads target. We had been sharing the same libclang_rt.builtins.a for both wasi and wasip1-threads targets, but enabling atomics feature breaks non-threaded wasi target due to unnecessary feature dependencies.
https://github.com/apple/swift/pull/73077 will build libclang_rt.builtins.a separately and install wasi-sysroot under different directories for each target.