### PR TITLE
Compile corelibs with atomics and bulk-memory features enabled

### DIFF
--- a/.github/workflows/build-toolchain.yml
+++ b/.github/workflows/build-toolchain.yml
@@ -183,6 +183,9 @@ jobs:
 
       - run: ./swiftwasm-build/tools/build/install-build-sdk.sh ${{ matrix.scheme }}
       - run: ./swiftwasm-build/tools/git-swift-workspace --skip-history --verbose --scheme ${{ matrix.scheme }}
+        env:
+          # icu uses git-lfs and it fails to checkout due to https://github.com/git-lfs/git-lfs/issues/5749
+          GIT_CLONE_PROTECTION_ACTIVE: false
 
       - name: Install Homebrew dependencies
         if: ${{ startsWith(matrix.build_os, 'macos-') }}

--- a/schemes/main/build/build-foundation.sh
+++ b/schemes/main/build/build-foundation.sh
@@ -17,6 +17,13 @@ FOUNDATION_BUILD="$SOURCE_PATH/build/WebAssembly/foundation-$TRIPLE"
 mkdir -p $FOUNDATION_BUILD
 cd $FOUNDATION_BUILD
 
+swift_extra_flags=""
+c_extra_flags=""
+if [[ "$TRIPLE" == "wasm32-unknown-wasip1-threads" ]]; then
+  swift_extra_flags="-Xcc -matomics -Xcc -mbulk-memory -Xcc -mthread-model -Xcc posix -Xcc -pthread -Xcc -ftls-model=local-exec"
+  c_extra_flags="-mthread-model posix -pthread -ftls-model=local-exec"
+fi
+
 cmake -G Ninja \
   -DCMAKE_BUILD_TYPE="Release" \
   -DCMAKE_SYSROOT="$WASI_SYSROOT_PATH" \
@@ -36,8 +43,8 @@ cmake -G Ninja \
   -DFOUNDATION_BUILD_TOOLS=OFF \
   -DHAS_LIBDISPATCH_API=OFF \
   -DCMAKE_Swift_COMPILER_FORCED=ON \
-  -DCMAKE_Swift_FLAGS="-sdk $WASI_SYSROOT_PATH -resource-dir $DESTINATION_TOOLCHAIN/usr/lib/swift_static" \
-  -DCMAKE_C_FLAGS="-resource-dir $DESTINATION_TOOLCHAIN/usr/lib/swift_static/clang -B $LLVM_BIN_DIR" \
+  -DCMAKE_Swift_FLAGS="-sdk $WASI_SYSROOT_PATH -resource-dir $DESTINATION_TOOLCHAIN/usr/lib/swift_static $swift_extra_flags" \
+  -DCMAKE_C_FLAGS="-resource-dir $DESTINATION_TOOLCHAIN/usr/lib/swift_static/clang -B $LLVM_BIN_DIR $c_extra_flags" \
   "${SOURCE_PATH}/swift-corelibs-foundation"
   
 ninja

--- a/schemes/main/build/build-xctest.sh
+++ b/schemes/main/build/build-xctest.sh
@@ -15,6 +15,11 @@ BUILD_DIR="$SOURCE_PATH/build/WebAssembly/xctest-$TRIPLE"
 mkdir -p $BUILD_DIR
 cd $BUILD_DIR
 
+swift_extra_flags=""
+if [[ "$TRIPLE" == "wasm32-unknown-wasip1-threads" ]]; then
+  swift_extra_flags="-Xcc -matomics -Xcc -mbulk-memory -Xcc -mthread-model -Xcc posix -Xcc -pthread -Xcc -ftls-model=local-exec"
+fi
+
 cmake -G Ninja \
   -DCMAKE_BUILD_TYPE="Release" \
   -DCMAKE_SYSROOT="$WASI_SYSROOT_PATH" \
@@ -26,7 +31,7 @@ cmake -G Ninja \
   -DCLANG_BIN="$CLANG_BIN_DIR" \
   -DBUILD_SHARED_LIBS=OFF \
   -DCMAKE_Swift_COMPILER_FORCED=ON \
-  -DCMAKE_Swift_FLAGS="-sdk $WASI_SYSROOT_PATH -resource-dir $DESTINATION_TOOLCHAIN/usr/lib/swift_static" \
+  -DCMAKE_Swift_FLAGS="-sdk $WASI_SYSROOT_PATH -resource-dir $DESTINATION_TOOLCHAIN/usr/lib/swift_static $swift_extra_flags" \
   -DSWIFT_FOUNDATION_PATH=$DESTINATION_TOOLCHAIN/usr/lib/swift_static/wasi/wasm32 \
   "${SOURCE_PATH}/swift-corelibs-xctest"
   


### PR DESCRIPTION
Those features must be consistently enabled across all objects in the linking process, so we need to enable them in the corelibs as well.