### PR TITLE
Enable threads support in  icu4c and libxml2

### DIFF
--- a/schemes/main/build/build-foundation.sh
+++ b/schemes/main/build/build-foundation.sh
@@ -10,7 +10,7 @@ TRIPLE="$6"
 SOURCE_PATH="$(cd "$(dirname $0)/../../../.." && pwd)"
 SCHEME_BUILD_PATH="$(cd "$(dirname $0)" && pwd)"
 BUILD_SDK_PATH="$SOURCE_PATH/build-sdk"
-LIBXML2_PATH="$BUILD_SDK_PATH/libxml2"
+LIBXML2_PATH="$BUILD_SDK_PATH/libxml2-$TRIPLE"
 
 FOUNDATION_BUILD="$SOURCE_PATH/build/WebAssembly/foundation-$TRIPLE"
 
@@ -33,7 +33,7 @@ cmake -G Ninja \
   -DTRIPLE="$TRIPLE" \
   -DLLVM_BIN="$LLVM_BIN_DIR" \
   -DCLANG_BIN="$CLANG_BIN_DIR" \
-  -DICU_ROOT="$BUILD_SDK_PATH/icu" \
+  -DICU_ROOT="$BUILD_SDK_PATH/icu-$TRIPLE" \
   -DLIBXML2_INCLUDE_DIR="$LIBXML2_PATH/include/libxml2" \
   -DLIBXML2_LIBRARY="$LIBXML2_PATH/lib" \
   -DBUILD_SHARED_LIBS=OFF \

--- a/schemes/main/manifest.json
+++ b/schemes/main/manifest.json
@@ -1,6 +1,13 @@
 {
   "base-tag": "swift-DEVELOPMENT-SNAPSHOT-2024-05-01-a",
   "build-compiler": false,
-  "icu4c": "https://github.com/swiftwasm/icu4c-wasi/releases/download/0.8.0/icu4c-wasi.tar.xz",
+  "icu4c": [
+    "https://github.com/swiftwasm/icu4c-wasi/releases/download/0.10.0/icu4c-wasm32-unknown-wasi.tar.xz",
+    "https://github.com/swiftwasm/icu4c-wasi/releases/download/0.10.0/icu4c-wasm32-unknown-wasip1-threads.tar.xz"
+  ],
+  "libxml2": [
+    "https://github.com/swiftwasm/libxml2-wasm/releases/download/2.0.0/libxml2-wasm32-unknown-wasi.tar.gz",
+    "https://github.com/swiftwasm/libxml2-wasm/releases/download/2.0.0/libxml2-wasm32-unknown-wasip1-threads.tar.gz"
+  ],
   "swift-org-download-channel": "development"
 }

--- a/schemes/release-5.10/manifest.json
+++ b/schemes/release-5.10/manifest.json
@@ -5,7 +5,8 @@
     "swift-corelibs-foundation": "660624d0220c0efbef054f4919f9f01fd3866be1",
     "swift-corelibs-xctest": "77bc9f5386ee8a2a4e8da5ac30e846b451d101b6"
   },
-  "icu4c": "https://github.com/swiftwasm/icu4c-wasi/releases/download/0.5.0/icu4c-wasi.tar.xz",
+  "icu4c": ["https://github.com/swiftwasm/icu4c-wasi/releases/download/0.5.0/icu4c-wasi.tar.xz"],
+  "libxml2": ["https://github.com/swiftwasm/libxml2-wasm/releases/download/2.0.0/libxml2-wasm32-unknown-wasi.tar.gz"],
   "wasi-sysroot": "https://github.com/swiftwasm/wasi-sdk-build/releases/download/wasi-sdk-14%2Bswiftwasm-2022-03-13/wasi-sysroot.tar.gz",
   "swift-org-download-channel": "swift-5.10-branch"
 }

--- a/schemes/release-5.9/manifest.json
+++ b/schemes/release-5.9/manifest.json
@@ -5,7 +5,8 @@
     "swift-corelibs-foundation": "660624d0220c0efbef054f4919f9f01fd3866be1",
     "swift-corelibs-xctest": "77bc9f5386ee8a2a4e8da5ac30e846b451d101b6"
   },
-  "icu4c": "https://github.com/swiftwasm/icu4c-wasi/releases/download/0.5.0/icu4c-wasi.tar.xz",
+  "icu4c": ["https://github.com/swiftwasm/icu4c-wasi/releases/download/0.5.0/icu4c-wasi.tar.xz"],
+  "libxml2": ["https://github.com/swiftwasm/libxml2-wasm/releases/download/2.0.0/libxml2-wasm32-unknown-wasi.tar.gz"],
   "wasi-sysroot": "https://github.com/swiftwasm/wasi-sdk-build/releases/download/wasi-sdk-14%2Bswiftwasm-2022-03-13/wasi-sysroot.tar.gz",
   "swift-org-download-channel": "swift-5.9.2-release"
 }

--- a/schemes/release-6.0/manifest.json
+++ b/schemes/release-6.0/manifest.json
@@ -2,7 +2,8 @@
   "update-checkout-scheme": "release/6.0",
   "base-tag": "swift-6.0-DEVELOPMENT-SNAPSHOT-2024-04-30-a",
   "build-compiler": false,
-  "icu4c": "https://github.com/swiftwasm/icu4c-wasi/releases/download/0.8.0/icu4c-wasi.tar.xz",
+  "icu4c": ["https://github.com/swiftwasm/icu4c-wasi/releases/download/0.8.0/icu4c-wasi.tar.xz"],
+  "libxml2": ["https://github.com/swiftwasm/libxml2-wasm/releases/download/2.0.0/libxml2-wasm32-unknown-wasi.tar.gz"],
   "wasi-sysroot": "https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-21/wasi-sysroot-21.0.tar.gz",
   "swift-org-download-channel": "swift-6.0-branch"
 }

--- a/tools/build/install-build-sdk.sh
+++ b/tools/build/install-build-sdk.sh
@@ -10,22 +10,25 @@ SCHEME_DIR="$(cd "$(dirname "$0")/../../schemes/$SCHEME" && pwd)"
 CURRENT_SCHEME_FILE="$BUILD_SDK_PATH/scheme"
 
 install_libxml2() {
-  LIBXML2_URL="https://github.com/swiftwasm/libxml2-wasm/releases/download/1.0.0/libxml2-wasm32-unknown-wasi.tar.gz"
-  curl -L "$LIBXML2_URL" | tar xz
-  rm -rf "$BUILD_SDK_PATH/libxml2"
-  mv libxml2-wasm32-unknown-wasi "$BUILD_SDK_PATH/libxml2"
+  read -r -a LIBXML2_URLS <<< "$(python3 -c 'import sys, json; print(" ".join(json.load(sys.stdin)["libxml2"]))' < "$SCHEME_DIR/manifest.json")"
+  for url in "${LIBXML2_URLS[@]}"; do
+    curl -L "$url" | tar xz -C "$BUILD_SDK_PATH"
+  done
+  # For backward compatibility
+  if [ "$SCHEME" = "release-5.9" ] || [ "$SCHEME" = "release-5.10" ] || [ "$SCHEME" = "release-6.0" ]; then
+    ln -sf libxml2-wasm32-unknown-wasi "$BUILD_SDK_PATH/libxml2"
+  fi
 }
 
 install_icu() {
-  local ICU_URL
-  ICU_URL="$(python3 -c 'import sys, json; print(json.load(sys.stdin)["icu4c"])' < "$SCHEME_DIR/manifest.json")"
-  curl -L "$ICU_URL" | tar Jx
+  read -r -a ICU_URLS <<< "$(python3 -c 'import sys, json; print(" ".join(json.load(sys.stdin)["icu4c"]))' < "$SCHEME_DIR/manifest.json")"
   rm -rf "$BUILD_SDK_PATH/icu"
-  if [ -d "icu_out" ]; then
-    # Just for backward compatibility
-    mv icu_out "$BUILD_SDK_PATH/icu"
-  else
-    mv icu "$BUILD_SDK_PATH/icu"
+  for url in "${ICU_URLS[@]}"; do
+    curl -L "$url" | tar Jx -C "$BUILD_SDK_PATH"
+  done
+  # Just for backward compatibility
+  if [ -d "$BUILD_SDK_PATH/icu_out" ]; then
+    mv $BUILD_SDK_PATH/icu_out "$BUILD_SDK_PATH/icu"
   fi
 }
 

--- a/tools/build/package-toolchain
+++ b/tools/build/package-toolchain
@@ -44,9 +44,12 @@ def derive_wasi_sysroot(options, packaging_dir: str, target_triple: str) -> str:
         return os.path.join(packaging_dir, 'wasi-sysroot', target_triple)
 
 
-def copy_icu_libs(build_sdk_path, dist_toolchain_path):
+def copy_icu_libs(build_sdk_path, dist_toolchain_path, target_triple):
     import shutil
-    icu_lib_dir = os.path.join(build_sdk_path, 'icu', 'lib')
+    icu_lib_dir = os.path.join(build_sdk_path, f"icu-{target_triple}", 'lib')
+    if not os.path.exists(icu_lib_dir):
+        icu_lib_dir = os.path.join(build_sdk_path, 'icu', 'lib')
+
     dest_dir = os.path.join(
         dist_toolchain_path, 'usr', 'lib', 'swift_static', 'wasi')
     print("=====> Copying ICU libraries from {}".format(icu_lib_dir))
@@ -56,9 +59,12 @@ def copy_icu_libs(build_sdk_path, dist_toolchain_path):
         shutil.copy(os.path.join(icu_lib_dir, lib), dest_path)
 
 
-def copy_libxml2_libs(build_sdk_path, dist_toolchain_path):
+def copy_libxml2_libs(build_sdk_path, dist_toolchain_path, target_triple):
     import shutil
-    lib_dir = os.path.join(build_sdk_path, 'libxml2', 'lib')
+    lib_dir = os.path.join(build_sdk_path, f"libxml2-{target_triple}", 'lib')
+    if not os.path.exists(lib_dir):
+        lib_dir = os.path.join(build_sdk_path, 'libxml2', 'lib')
+
     dest_dir = os.path.join(
         dist_toolchain_path, 'usr', 'lib', 'swift_static', 'wasi')
     print("=====> Copying libxml2 libraries from {}".format(lib_dir))
@@ -90,8 +96,8 @@ class PackageAction(Action):
         print(f"=====> Copying base snapshot {base_toolchain_path} to {dist_toolchain_path}")
         self.rsync("-a", base_toolchain_path + "/", dist_toolchain_path)
 
-        copy_icu_libs(build_sdk_path, target_toolchain_path)
-        copy_libxml2_libs(build_sdk_path, target_toolchain_path)
+        copy_icu_libs(build_sdk_path, target_toolchain_path, self.target_triple)
+        copy_libxml2_libs(build_sdk_path, target_toolchain_path, self.target_triple)
         # Copying target stdlib to dist toolchain, and cross compiler if
         # host compiler is built with patches by ourselves.
         print(f"=====> Copying target toolchain {target_toolchain_path} to {dist_toolchain_path}")
@@ -219,8 +225,8 @@ class PackageSwiftSDKAction(Action):
 
     def run(self):
         build_sdk_path = os.path.join('..', 'build-sdk')
-        copy_icu_libs(build_sdk_path, self.target_toolchain_path)
-        copy_libxml2_libs(build_sdk_path, self.target_toolchain_path)
+        copy_icu_libs(build_sdk_path, self.target_toolchain_path, self.target_triple)
+        copy_libxml2_libs(build_sdk_path, self.target_toolchain_path, self.target_triple)
         self.make_swift_sdk(
             self.base_toolchain_path,
             self.host_toolchain_path,


### PR DESCRIPTION
Follow up to https://github.com/swiftwasm/swiftwasm-build/pull/311

Dependencies of corelibs should also be thread-enabled. The new build-sdk directory layout is as follows:

```
$ tree -L 2 ../build-sdk
../build-sdk
├── icu-wasm32-unknown-wasi
│   ├── bin
│   ├── include
│   ├── lib
│   ├── sbin
│   └── share
├── icu-wasm32-unknown-wasip1-threads
│   ├── bin
│   ├── include
│   ├── lib
│   ├── sbin
│   └── share
├── libxml2-wasm32-unknown-wasi
│   ├── include
│   └── lib
├── libxml2-wasm32-unknown-wasip1-threads
│   ├── include
│   └── lib
└── scheme

```