### PR TITLE
We no longer need pre-built ICU libraries

### DIFF
--- a/schemes/main/manifest.json
+++ b/schemes/main/manifest.json
@@ -1,10 +1,7 @@
 {
   "base-tag": "swift-DEVELOPMENT-SNAPSHOT-2024-09-17-a",
   "build-compiler": false,
-  "icu4c": [
-    "https://github.com/swiftwasm/icu4c-wasi/releases/download/0.10.0/icu4c-wasm32-unknown-wasi.tar.xz",
-    "https://github.com/swiftwasm/icu4c-wasi/releases/download/0.10.0/icu4c-wasm32-unknown-wasip1-threads.tar.xz"
-  ],
+  "icu4c": [],
   "libxml2": [
     "https://github.com/swiftwasm/libxml2-wasm/releases/download/2.0.0/libxml2-wasm32-unknown-wasi.tar.gz",
     "https://github.com/swiftwasm/libxml2-wasm/releases/download/2.0.0/libxml2-wasm32-unknown-wasip1-threads.tar.gz"

--- a/tools/build/install-build-sdk.sh
+++ b/tools/build/install-build-sdk.sh
@@ -11,6 +11,7 @@ CURRENT_SCHEME_FILE="$BUILD_SDK_PATH/scheme"
 
 install_libxml2() {
   read -r -a LIBXML2_URLS <<< "$(python3 -c 'import sys, json; print(" ".join(json.load(sys.stdin)["libxml2"]))' < "$SCHEME_DIR/manifest.json")"
+  [ -z "${LIBXML2_URLS+x}" ] && return
   for url in "${LIBXML2_URLS[@]}"; do
     curl -L "$url" | tar xz -C "$BUILD_SDK_PATH"
   done
@@ -22,6 +23,7 @@ install_libxml2() {
 
 install_icu() {
   read -r -a ICU_URLS <<< "$(python3 -c 'import sys, json; print(" ".join(json.load(sys.stdin)["icu4c"]))' < "$SCHEME_DIR/manifest.json")"
+  [ -z "${ICU_URLS+x}" ] && return
   rm -rf "$BUILD_SDK_PATH/icu"
   for url in "${ICU_URLS[@]}"; do
     curl -L "$url" | tar Jx -C "$BUILD_SDK_PATH"

--- a/tools/build/package-toolchain
+++ b/tools/build/package-toolchain
@@ -44,7 +44,10 @@ def derive_wasi_sysroot(options, packaging_dir: str, target_triple: str) -> str:
         return os.path.join(packaging_dir, 'wasi-sysroot', target_triple)
 
 
-def copy_icu_libs(build_sdk_path, dist_toolchain_path, target_triple):
+def copy_icu_libs(scheme, build_sdk_path, dist_toolchain_path, target_triple):
+    if scheme not in ["release-5.9", "release-5.10", "release-6.0"]:
+        # We don't need to copy ICU libraries for recent channels
+        return
     import shutil
     icu_lib_dir = os.path.join(build_sdk_path, f"icu-{target_triple}", 'lib')
     if not os.path.exists(icu_lib_dir):
@@ -96,7 +99,7 @@ class PackageAction(Action):
         print(f"=====> Copying base snapshot {base_toolchain_path} to {dist_toolchain_path}")
         self.rsync("-a", base_toolchain_path + "/", dist_toolchain_path)
 
-        copy_icu_libs(build_sdk_path, target_toolchain_path, self.target_triple)
+        copy_icu_libs(self.options.scheme, build_sdk_path, target_toolchain_path, self.target_triple)
         copy_libxml2_libs(build_sdk_path, target_toolchain_path, self.target_triple)
         # Copying target stdlib to dist toolchain, and cross compiler if
         # host compiler is built with patches by ourselves.
@@ -215,7 +218,7 @@ class PackageSwiftSDKAction(Action):
 
     def run(self):
         build_sdk_path = os.path.join('..', 'build-sdk')
-        copy_icu_libs(build_sdk_path, self.target_toolchain_path, self.target_triple)
+        copy_icu_libs(self.options.scheme, build_sdk_path, self.target_toolchain_path, self.target_triple)
         copy_libxml2_libs(build_sdk_path, self.target_toolchain_path, self.target_triple)
         self.make_swift_sdk(
             self.base_toolchain_path,


### PR DESCRIPTION
We now build ICU from source in swift-foundation-icu, so we no longer need to download pre-built ICU libraries.