### PR TITLE
Build swift-foundation-icu with `-fno-exceptions`

### DIFF
--- a/schemes/main/build/build-foundation.sh
+++ b/schemes/main/build/build-foundation.sh
@@ -43,7 +43,7 @@ cmake -G Ninja \
   -D CMAKE_CXX_COMPILER_FORCED=ON \
   -D CMAKE_Swift_FLAGS="-sdk $WASI_SYSROOT_PATH -resource-dir $DESTINATION_TOOLCHAIN/usr/lib/swift_static $swift_extra_flags" \
   -D CMAKE_C_FLAGS="-resource-dir $DESTINATION_TOOLCHAIN/usr/lib/swift_static/clang -B $LLVM_BIN_DIR $c_extra_flags" \
-  -D CMAKE_CXX_FLAGS="-resource-dir $DESTINATION_TOOLCHAIN/usr/lib/swift_static/clang -B $LLVM_BIN_DIR $c_extra_flags" \
+  -D CMAKE_CXX_FLAGS="-fno-exceptions -resource-dir $DESTINATION_TOOLCHAIN/usr/lib/swift_static/clang -B $LLVM_BIN_DIR $c_extra_flags" \
   -D _SwiftCollections_SourceDIR="$SOURCE_PATH/swift-collections" \
   -D _SwiftFoundation_SourceDIR="$SOURCE_PATH/swift-foundation" \
   -D _SwiftFoundationICU_SourceDIR="$SOURCE_PATH/swift-foundation-icu" \


### PR DESCRIPTION
STL uses C++ exceptions for some places, so we need to disable them explicitly even though ICU itself does not use exceptions.