### PR TITLE
Add release-6.4 snapshot scheme

### DIFF
--- a/.github/scripts/build-matrix.rb
+++ b/.github/scripts/build-matrix.rb
@@ -14,6 +14,7 @@ BASE_MATRIX_ENTRIES = [
       "release-6.1": "ghcr.io/swiftwasm/swift-ci:main-ubuntu-20.04@sha256:06faf7795ea077b64986b1c821a27b2756242ebe6d73adcdae17f4e424c17dc5",
       "release-6.2": "ghcr.io/swiftwasm/swift-ci:main-ubuntu-20.04@sha256:ef0e9e4ff5b457103d8a060573050d9b33c91d9f680f7d4202412a99dc52cde0",
       "release-6.3": "ghcr.io/swiftwasm/swift-ci:main-ubuntu-20.04@sha256:ef0e9e4ff5b457103d8a060573050d9b33c91d9f680f7d4202412a99dc52cde0",
+      "release-6.4": "ghcr.io/swiftwasm/swift-ci:main-ubuntu-20.04@sha256:ef0e9e4ff5b457103d8a060573050d9b33c91d9f680f7d4202412a99dc52cde0",
     },
     "run_stdlib_test": true,
     "run_full_test": false,

--- a/schemes/release-6.4/build/build-target-toolchain.sh
+++ b/schemes/release-6.4/build/build-target-toolchain.sh
@@ -123,7 +123,7 @@ main() {
     "$OPTIONS_SWIFT_BIN"
   )
 
-  build_target_toolchain "${BUILD_TOOLS_ARGS[@]}" "wasm32-unknown-wasi" "wasi-wasm32" "wasm32-wasi" "wasistdlib" "wasi"
+  build_target_toolchain "${BUILD_TOOLS_ARGS[@]}" "wasm32-unknown-wasip1" "wasip1-wasm32" "wasm32-wasip1" "wasistdlib" "wasip1"
   build_target_toolchain "${BUILD_TOOLS_ARGS[@]}" "wasm32-unknown-wasip1-threads" "wasip1-threads-wasm32" "wasm32-wasip1-threads" "wasithreadsstdlib" "wasip1"
 
   rsync -av "$WASI_SYSROOT_PATH/" "$PACKAGING_DIR/wasi-sysroot/"

--- a/schemes/release-6.4/build/build-target-toolchain.sh
+++ b/schemes/release-6.4/build/build-target-toolchain.sh
@@ -26,13 +26,13 @@ build_target_toolchain() {
   local TRIPLE="$4"
 
   local HOST_SUFFIX
-  HOST_SUFFIX=$(find "$TARGET_BUILD_ROOT" -name "wasmstdlib-*" -exec basename {} \; | sed 's/wasmstdlib-//')
+  HOST_SUFFIX=$(find "$TARGET_BUILD_ROOT" -name "wasistdlib-*" -exec basename {} \; | sed 's/wasistdlib-//')
 
   local TRIPLE_DESTDIR="$TARGET_TOOLCHAIN_DESTDIR/$TRIPLE"
 
   rm -rf "$TRIPLE_DESTDIR"
   mkdir -p "$TRIPLE_DESTDIR"
-  cp -R "$TARGET_BUILD_ROOT/wasmswiftsdk-$HOST_SUFFIX/Toolchains/$TRIPLE/usr" "$TRIPLE_DESTDIR/usr"
+  cp -R "$TARGET_BUILD_ROOT/wasiswiftsdk-$HOST_SUFFIX/Toolchains/$TRIPLE/usr" "$TRIPLE_DESTDIR/usr"
 }
 
 main() {
@@ -88,7 +88,7 @@ main() {
 
   # NOTE: The llvm-cmake-options is a workaround for the issue on amazonlinux2
   # See https://github.com/apple/swift/commit/40c7268e8f7d402b27e3ad16a84180e07c37f92c
-  # NOTE: Add llvm-bin directory to PATH so that wasmstdlib.py can find FileCheck during tests
+  # NOTE: Add llvm-bin directory to PATH so that wasistdlib.py can find FileCheck during tests
   env PATH="$OPTIONS_LLVM_BIN:$OPTIONS_SWIFT_BIN:$PATH" "$SOURCE_PATH/swift/utils/build-script" \
     --build-subdir=WebAssembly \
     --release \
@@ -98,8 +98,9 @@ main() {
     --skip-build-benchmarks \
     --skip-early-swift-driver \
     --wasmkit \
-    --build-wasm-stdlib \
-    --skip-test-wasm-stdlib \
+    --skip-test-wasi-stdlib \
+    --build-wasi-stdlib \
+    --skip-test-wasi-stdlib \
     --native-swift-tools-path="$OPTIONS_SWIFT_BIN" \
     --native-clang-tools-path="$OPTIONS_CLANG_BIN" \
     --native-llvm-tools-path="$OPTIONS_LLVM_BIN" \
@@ -122,8 +123,8 @@ main() {
     "$OPTIONS_SWIFT_BIN"
   )
 
-  build_target_toolchain "${BUILD_TOOLS_ARGS[@]}" "wasm32-unknown-wasip1" "wasip1-wasm32" "wasm32-wasip1" "wasmstdlib" "wasip1"
-  build_target_toolchain "${BUILD_TOOLS_ARGS[@]}" "wasm32-unknown-wasip1-threads" "wasip1-threads-wasm32" "wasm32-wasip1-threads" "wasmthreadsstdlib" "wasip1"
+  build_target_toolchain "${BUILD_TOOLS_ARGS[@]}" "wasm32-unknown-wasi" "wasi-wasm32" "wasm32-wasi" "wasistdlib" "wasi"
+  build_target_toolchain "${BUILD_TOOLS_ARGS[@]}" "wasm32-unknown-wasip1-threads" "wasip1-threads-wasm32" "wasm32-wasip1-threads" "wasithreadsstdlib" "wasip1"
 
   rsync -av "$WASI_SYSROOT_PATH/" "$PACKAGING_DIR/wasi-sysroot/"
 }

--- a/schemes/release-6.4/build/build-target-toolchain.sh
+++ b/schemes/release-6.4/build/build-target-toolchain.sh
@@ -1,0 +1,131 @@
+#!/bin/bash
+#
+# Build the Swift standard library.
+
+set -euo pipefail
+set -x
+
+print_help() {
+  echo "Usage: $0 [options]"
+  echo ""
+  echo "Options:"
+  echo "  --help               Display this help message."
+  echo "  --llvm-bin           Path to LLVM bin directory."
+  echo "  --swift-bin          Path to Swift bin directory."
+}
+
+SCHEMES_BUILD_PATH="$(cd "$(dirname "$0")" && pwd)"
+SOURCE_PATH="$(cd "$(dirname "$0")/../../../.." && pwd)"
+TARGET_BUILD_ROOT=$SOURCE_PATH/build/WebAssembly
+WASI_SYSROOT_PATH="$TARGET_BUILD_ROOT/wasi-sysroot"
+PACKAGING_DIR="$SOURCE_PATH/build/Packaging"
+TARGET_TOOLCHAIN_DESTDIR=$PACKAGING_DIR/target-toolchain
+
+build_target_toolchain() {
+
+  local TRIPLE="$4"
+
+  local HOST_SUFFIX
+  HOST_SUFFIX=$(find "$TARGET_BUILD_ROOT" -name "wasmstdlib-*" -exec basename {} \; | sed 's/wasmstdlib-//')
+
+  local TRIPLE_DESTDIR="$TARGET_TOOLCHAIN_DESTDIR/$TRIPLE"
+
+  rm -rf "$TRIPLE_DESTDIR"
+  mkdir -p "$TRIPLE_DESTDIR"
+  cp -R "$TARGET_BUILD_ROOT/wasmswiftsdk-$HOST_SUFFIX/Toolchains/$TRIPLE/usr" "$TRIPLE_DESTDIR/usr"
+}
+
+main() {
+  local OPTIONS_LLVM_BIN=""
+  local OPTIONS_CLANG_BIN=""
+  local OPTIONS_SWIFT_BIN=""
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --llvm-bin)
+        OPTIONS_LLVM_BIN="$2"
+        shift 2
+        ;;
+      --clang-bin)
+        OPTIONS_CLANG_BIN="$2"
+        shift 2
+        ;;
+      --swift-bin)
+        OPTIONS_SWIFT_BIN="$2"
+        shift 2
+        ;;
+      --scheme)
+        OPTIONS_SCHEME="$2"
+        shift 2
+        ;;
+      --help)
+        print_help
+        exit 0
+        ;;
+      *)
+        echo "Unknown option: $1"
+        print_help
+        exit 1
+        ;;
+    esac
+  done
+
+  if [[ -z "$OPTIONS_LLVM_BIN" ]]; then
+    echo "Missing --llvm-bin option"
+    print_help
+    exit 1
+  fi
+
+  if [[ -z "$OPTIONS_SWIFT_BIN" ]]; then
+    echo "Missing --swift-bin option"
+    print_help
+    exit 1
+  fi
+
+  if [[ -z "$OPTIONS_CLANG_BIN" ]]; then
+    OPTIONS_CLANG_BIN="$OPTIONS_LLVM_BIN"
+  fi
+
+  # NOTE: The llvm-cmake-options is a workaround for the issue on amazonlinux2
+  # See https://github.com/apple/swift/commit/40c7268e8f7d402b27e3ad16a84180e07c37f92c
+  # NOTE: Add llvm-bin directory to PATH so that wasmstdlib.py can find FileCheck during tests
+  env PATH="$OPTIONS_LLVM_BIN:$OPTIONS_SWIFT_BIN:$PATH" "$SOURCE_PATH/swift/utils/build-script" \
+    --build-subdir=WebAssembly \
+    --release \
+    --skip-build-llvm \
+    --skip-build-swift \
+    --skip-build-cmark \
+    --skip-build-benchmarks \
+    --skip-early-swift-driver \
+    --wasmkit \
+    --build-wasm-stdlib \
+    --skip-test-wasm-stdlib \
+    --native-swift-tools-path="$OPTIONS_SWIFT_BIN" \
+    --native-clang-tools-path="$OPTIONS_CLANG_BIN" \
+    --native-llvm-tools-path="$OPTIONS_LLVM_BIN" \
+    --build-runtime-with-host-compiler \
+    --extra-cmake-options="\
+      -DSWIFT_STDLIB_TRACING=NO \
+      -DSWIFT_STDLIB_HAS_ASL=NO \
+      -DSWIFT_STDLIB_CONCURRENCY_TRACING=NO \
+      -DSWIFT_RUNTIME_CRASH_REPORTER_CLIENT=NO \
+      -DSWIFT_STDLIB_INSTALL_PARENT_MODULE_FOR_SHIMS=NO \
+    " \
+    --llvm-cmake-options="\
+      -DCROSS_TOOLCHAIN_FLAGS_LLVM_NATIVE='-DCMAKE_C_COMPILER=clang;-DCMAKE_CXX_COMPILER=clang++' \
+    " \
+    --sccache
+
+  local BUILD_TOOLS_ARGS=(
+    "$OPTIONS_LLVM_BIN"
+    "$OPTIONS_CLANG_BIN"
+    "$OPTIONS_SWIFT_BIN"
+  )
+
+  build_target_toolchain "${BUILD_TOOLS_ARGS[@]}" "wasm32-unknown-wasip1" "wasip1-wasm32" "wasm32-wasip1" "wasmstdlib" "wasip1"
+  build_target_toolchain "${BUILD_TOOLS_ARGS[@]}" "wasm32-unknown-wasip1-threads" "wasip1-threads-wasm32" "wasm32-wasip1-threads" "wasmthreadsstdlib" "wasip1"
+
+  rsync -av "$WASI_SYSROOT_PATH/" "$PACKAGING_DIR/wasi-sysroot/"
+}
+
+main "$@"

--- a/schemes/release-6.4/build/run-test.sh
+++ b/schemes/release-6.4/build/run-test.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+set -euxo pipefail
+
+echo "Skipping test because we now run tests in build-script"

--- a/schemes/release-6.4/manifest.json
+++ b/schemes/release-6.4/manifest.json
@@ -1,5 +1,5 @@
 {
-  "update-checkout-scheme": "release/6.4",
+  "update-checkout-scheme": "release/6.4.x",
   "base-tag": "swift-6.4.x-DEVELOPMENT-SNAPSHOT-2026-06-08-a",
   "icu4c": [],
   "libxml2": [],

--- a/schemes/release-6.4/manifest.json
+++ b/schemes/release-6.4/manifest.json
@@ -1,0 +1,7 @@
+{
+  "update-checkout-scheme": "release/6.4",
+  "base-tag": "swift-6.4.x-DEVELOPMENT-SNAPSHOT-2026-06-08-a",
+  "icu4c": [],
+  "libxml2": [],
+  "swift-org-download-channel": "swift-6.4.x-branch"
+}


### PR DESCRIPTION
Adds a new release-6.4 scheme for Swift 6.4.x snapshots and wires the scheme into the CI build matrix.\n\nValidation:\n- bash -n on the new shell scripts\n- ruby -c .github/scripts/build-matrix.rb\n- git diff --check