### PR TITLE
Update release-6.3 manifest to Swift 6.3.2

### DIFF
--- a/schemes/release-6.3/manifest.json
+++ b/schemes/release-6.3/manifest.json
@@ -1,7 +1,7 @@
 {
   "update-checkout-scheme": "release/6.3",
-  "base-tag": "swift-6.3-RELEASE",
+  "base-tag": "swift-6.3.2-RELEASE",
   "icu4c": [],
   "libxml2": [],
-  "swift-org-download-channel": "swift-6.3-release"
+  "swift-org-download-channel": "swift-6.3.2-release"
 }


### PR DESCRIPTION
## Summary
- Bump `schemes/release-6.3/manifest.json` to the latest stable 6.3.x release
- Update the base tag and Swift.org download channel to `6.3.2`

## Testing
- Not run (not requested)